### PR TITLE
Remove print statement in rocher.py

### DIFF
--- a/rocher/rocher.py
+++ b/rocher/rocher.py
@@ -61,7 +61,6 @@ def _monaco_editor(method: str, container_id: str, **kwargs) -> str:
             return  monaco.editor.{method}(document.getElementById('{container_id}'), {{
     """
     output += json.dumps(kwargs)[1:-1]
-    print(output)
     output += """});
             });
     </script>


### PR DESCRIPTION
Related to #2

Remove the print statement in the `_monaco_editor` function to enhance performance.

* Remove the print statement in the `_monaco_editor` function in `rocher/rocher.py` at line 64.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julien-duponchelle/rocher/issues/2?shareId=c9f6fc70-080d-4820-96ca-caa969a4d160).